### PR TITLE
Upload updated version of chebi_lite (31/08/2019)

### DIFF
--- a/src/tawny_chebi/chebi.clj
+++ b/src/tawny_chebi/chebi.clj
@@ -65,9 +65,13 @@
   :filter
   (partial tawny.read/iri-starts-with-filter
            "http://purl.obolibrary.org/obo/CHEBI")
+  :filter
+  tawny.read/label-transform
+  
   :transform
   tawny.read/exception-nil-label-transform
   )
+
 
 ;; (println chebi)
 ;; (clojure.core/ns-publics 'tawny-chebi.chebi)


### PR DESCRIPTION
The old version of chebi_lite is missing some terms such as CHEBI:138054